### PR TITLE
Removendo Println ao adicionar Job para evitar poluir o terminal

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -130,7 +130,6 @@ func (publisher *Publisher) AddJob(
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(jsonData))
 	jsonOption, err := json.Marshal(opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
Removendo o `fmt.Println` para evitar poluir terminal, além de evitar conflitos ao utilizar a biblioteca em outro código que já possui método de `log`